### PR TITLE
fix #2. Initialization fails with Markdown 2.5.2

### DIFF
--- a/md_yaml/mdx_meta_yaml/__init__.py
+++ b/md_yaml/mdx_meta_yaml/__init__.py
@@ -5,4 +5,6 @@ from mdx_meta_yaml.extension import MetaYamlExtension
 def makeExtension(configs=None):
 	if isinstance(configs, list):
 		configs = dict(configs)
+        elif configs is None:
+		configs  = {}
 	return MetaYamlExtension(configs=configs)


### PR DESCRIPTION
Now, config param in makeExtension() can't be None -> waylan/Python-Markdown#357